### PR TITLE
Adds user agent info to requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ fmt:
 
 
 BUILD_VERSION:=${VERSION}-$(shell git log -n 1 --pretty=format:'%H')
-VER_FLAG:=--ldflags '-X github.com/capitalone/stack-deployment-tool/cmd.Version=$(BUILD_VERSION)'
+VER_FLAG:=--ldflags '-X github.com/capitalone/stack-deployment-tool/sdt.Version=$(BUILD_VERSION)'
 
 .PHONY: quick
 quick: build_darwin

--- a/sdt/version.go
+++ b/sdt/version.go
@@ -12,24 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and limitations under the License.
 //
-package cmd
+package sdt
 
-import (
-	"fmt"
-
-	"github.com/capitalone/stack-deployment-tool/sdt"
-	"github.com/spf13/cobra"
-)
-
-func init() {
-	RootCmd.AddCommand(versionCmd)
-}
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of Stack Deployment Tool",
-	Long:  `Print the version number of Stack Deployment Tool`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(sdt.Version)
-	},
-}
+var Version = "dev"


### PR DESCRIPTION
#5  Adds user agent info to requests, so that in CloudTrail the agent shows up like:

    "userAgent": "sdt/0.0.1-63215750bd4cba950600de8a0f60c4a3b42227d9 aws-sdk-go/1.5.8 (go1.7.3; darwin; amd64)",

